### PR TITLE
Integrate HAPI-FHIR library for server side communication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,9 +103,14 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-		    <groupId>ca.uhn.hapi.fhir</groupId>
-		    <artifactId>hapi-fhir-converter</artifactId>
-		    <version>3.4.0</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.7</version>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-converter</artifactId>
+			<version>3.4.0</version>
 		</dependency>
 		<!-- Required to work with LogManager in fhir2hpo dependency -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,35 @@
 			<artifactId>fhir2hpo</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-client</artifactId>
+			<version>3.4.0</version>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-structures-hl7org-dstu2</artifactId>
+			<version>3.4.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-io</groupId>
+					<artifactId>commons-io</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-codec</groupId>
+					<artifactId>commons-codec</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>ca.uhn.hapi.fhir</groupId>
+		    <artifactId>hapi-fhir-converter</artifactId>
+		    <version>3.4.0</version>
+		</dependency>
 		<!-- Required to work with LogManager in fhir2hpo dependency -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/src/main/java/org/octri/hpoonfhir/config/FhirConfig.java
+++ b/src/main/java/org/octri/hpoonfhir/config/FhirConfig.java
@@ -1,5 +1,6 @@
 package org.octri.hpoonfhir.config;
 
+import org.octri.hpoonfhir.service.FhirService;
 import org.octri.hpoonfhir.service.Stu2FhirService;
 import org.octri.hpoonfhir.service.Stu3FhirService;
 import org.springframework.context.annotation.Bean;
@@ -9,12 +10,12 @@ import org.springframework.context.annotation.Configuration;
 public class FhirConfig {
 	
 	@Bean
-	public Stu3FhirService r3FhirService() {
+	public FhirService r3FhirService() {
 		return new Stu3FhirService("https://r3.smarthealthit.org");
 	}
 
 	@Bean
-	public Stu2FhirService epicFhirService() {
+	public FhirService epicFhirService() {
 		return new Stu2FhirService("https://open-ic.epic.com/FHIR/api/FHIR/DSTU2");
 	}
 

--- a/src/main/java/org/octri/hpoonfhir/config/FhirConfig.java
+++ b/src/main/java/org/octri/hpoonfhir/config/FhirConfig.java
@@ -1,0 +1,21 @@
+package org.octri.hpoonfhir.config;
+
+import org.octri.hpoonfhir.service.Stu2FhirService;
+import org.octri.hpoonfhir.service.Stu3FhirService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FhirConfig {
+	
+	@Bean
+	public Stu3FhirService r3FhirService() {
+		return new Stu3FhirService("https://r3.smarthealthit.org");
+	}
+
+	@Bean
+	public Stu2FhirService epicFhirService() {
+		return new Stu2FhirService("https://open-ic.epic.com/FHIR/api/FHIR/DSTU2");
+	}
+
+}

--- a/src/main/java/org/octri/hpoonfhir/config/MustacheConfig.java
+++ b/src/main/java/org/octri/hpoonfhir/config/MustacheConfig.java
@@ -1,4 +1,4 @@
-package org.octri.hpoonfhir;
+package org.octri.hpoonfhir.config;
 
 import org.springframework.boot.autoconfigure.mustache.MustacheAutoConfiguration;
 import org.springframework.boot.autoconfigure.mustache.MustacheProperties;

--- a/src/main/java/org/octri/hpoonfhir/controller/MainController.java
+++ b/src/main/java/org/octri/hpoonfhir/controller/MainController.java
@@ -1,24 +1,36 @@
 package org.octri.hpoonfhir.controller;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.monarchinitiative.fhir2hpo.loinc.DefaultLoinc2HpoAnnotation;
 import org.monarchinitiative.fhir2hpo.loinc.Loinc2HpoAnnotation;
 import org.monarchinitiative.fhir2hpo.loinc.LoincId;
 import org.monarchinitiative.fhir2hpo.service.AnnotationService;
+import org.octri.hpoonfhir.service.Stu2FhirService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 public class MainController {
-	
+
 	@Autowired
 	AnnotationService annotationService;
+	
+	@Autowired
+	Stu2FhirService epicFhirService;
 
 	@RequestMapping("/")
 	public String search(Map<String, Object> model, HttpServletRequest request) {
+		try {
+			epicFhirService.findPatientsByFullName("Jason", "Argonaut");
+		} catch (Exception e) {
+			
+		}
 		return "search";
 	}
 
@@ -30,17 +42,21 @@ public class MainController {
 
 	@RequestMapping("/annotations")
 	public String annotations(Map<String, Object> model) throws Exception {
-		model.put("loincMap", annotationService.getAnnotationsMap().entrySet());
-		
+		Map<LoincId, Loinc2HpoAnnotation> annotations = annotationService.getAnnotationsMap();
+		List<LoincId> loincs = annotations.entrySet().stream()
+				.filter(x -> x.getValue() instanceof DefaultLoinc2HpoAnnotation).map(x -> x.getKey())
+				.collect(Collectors.toList());
+		model.put("loincs", loincs);
+
 		return "annotations";
 	}
-	
+
 	@RequestMapping("/hpo")
 	public String hpo(Map<String, Object> model, HttpServletRequest request) throws Exception {
 		String loincId = request.getParameter("loinc_id");
 		Loinc2HpoAnnotation annotation = annotationService.getAnnotations(new LoincId(loincId));
 		model.put("annotation", annotation.toString());
-		
+
 		return "hpo";
 	}
 

--- a/src/main/java/org/octri/hpoonfhir/controller/MainController.java
+++ b/src/main/java/org/octri/hpoonfhir/controller/MainController.java
@@ -56,13 +56,11 @@ public class MainController {
 		model.put("patientSearchForm", form);
 		try {
 			List<Patient> patients = fhirService.findPatientsByFullName(form.getFirstName(), form.getLastName());
-			List<PatientModel> patientModels = patients.stream().map(fhirPatient -> {
-				PatientModel patientModel = new PatientModel();
-				patientModel.setFirstName(fhirPatient.getNameFirstRep().getGivenAsSingleString());
-				patientModel.setLastName(fhirPatient.getNameFirstRep().getFamily());
-				patientModel.setId(fhirPatient.getIdElement().getIdPart());
-				return patientModel;
-			}).collect(Collectors.toList());
+			List<PatientModel> patientModels = patients.stream().map(fhirPatient -> 
+				new PatientModel(fhirPatient.getIdElement().getIdPart(),
+						fhirPatient.getNameFirstRep().getGivenAsSingleString(), 
+						fhirPatient.getNameFirstRep().getFamily())
+			).collect(Collectors.toList());
 			model.put("patients", patientModels);
 			model.put("results", true);
 		} catch (FHIRException e) {

--- a/src/main/java/org/octri/hpoonfhir/controller/MainController.java
+++ b/src/main/java/org/octri/hpoonfhir/controller/MainController.java
@@ -6,13 +6,20 @@ import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.exceptions.FHIRException;
 import org.monarchinitiative.fhir2hpo.loinc.DefaultLoinc2HpoAnnotation;
 import org.monarchinitiative.fhir2hpo.loinc.Loinc2HpoAnnotation;
 import org.monarchinitiative.fhir2hpo.loinc.LoincId;
 import org.monarchinitiative.fhir2hpo.service.AnnotationService;
-import org.octri.hpoonfhir.service.Stu2FhirService;
+import org.octri.hpoonfhir.service.FhirService;
+import org.octri.hpoonfhir.view.PatientModel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -22,17 +29,49 @@ public class MainController {
 	AnnotationService annotationService;
 	
 	@Autowired
-	Stu2FhirService epicFhirService;
+	@Qualifier("r3FhirService")
+	FhirService fhirService;
 
-	@RequestMapping("/")
-	public String search(Map<String, Object> model, HttpServletRequest request) {
+	/**
+	 * Return to a clean search form with no results.
+	 * @param model
+	 * @param request
+	 * @return
+	 */
+	@GetMapping("/")
+	public String home(Map<String, Object> model, HttpServletRequest request) {
+		model.put("patientSearchForm", new PatientModel());
+		model.put("results", false);
+		return "search";
+	}
+	
+	/**
+	 * Search using the form parameters, and return results.
+	 * @param model
+	 * @param form
+	 * @return
+	 */
+	@PostMapping("/search")
+	public String search(Map<String, Object> model, @ModelAttribute PatientModel form) {
+		model.put("patientSearchForm", form);
 		try {
-			epicFhirService.findPatientsByFullName("Jason", "Argonaut");
-		} catch (Exception e) {
-			
+			List<Patient> patients = fhirService.findPatientsByFullName(form.getFirstName(), form.getLastName());
+			List<PatientModel> patientModels = patients.stream().map(fhirPatient -> {
+				PatientModel patientModel = new PatientModel();
+				patientModel.setFirstName(fhirPatient.getNameFirstRep().getGivenAsSingleString());
+				patientModel.setLastName(fhirPatient.getNameFirstRep().getFamily());
+				patientModel.setId(fhirPatient.getIdElement().getIdPart());
+				return patientModel;
+			}).collect(Collectors.toList());
+			model.put("patients", patientModels);
+			model.put("results", true);
+		} catch (FHIRException e) {
+			//TODO: Decide how to handle FHIRException which is only thrown if there's an error in the conversion of V2 messages
+			e.printStackTrace();
 		}
 		return "search";
 	}
+
 
 	@RequestMapping("/labs")
 	public String labs(Map<String, Object> model, HttpServletRequest request) {

--- a/src/main/java/org/octri/hpoonfhir/service/AbstractFhirService.java
+++ b/src/main/java/org/octri/hpoonfhir/service/AbstractFhirService.java
@@ -1,0 +1,26 @@
+package org.octri.hpoonfhir.service;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+
+/**
+ * The extending STU2 and STU3 services set their own context and implement interface methods, returning STU3 entities.
+ * 
+ * @author yateam
+ */
+public abstract class AbstractFhirService implements FhirService {
+	
+	private final IGenericClient client;
+	
+	public abstract FhirContext getFhirContext();
+	
+	public AbstractFhirService(String url) {
+		getFhirContext().getRestfulClientFactory().setSocketTimeout(30 * 1000); // Extend the timeout
+		client = getFhirContext().newRestfulGenericClient(url);
+	}
+	
+	public IGenericClient getClient() {
+		return client;
+	}
+	
+}

--- a/src/main/java/org/octri/hpoonfhir/service/AbstractFhirService.java
+++ b/src/main/java/org/octri/hpoonfhir/service/AbstractFhirService.java
@@ -1,5 +1,7 @@
 package org.octri.hpoonfhir.service;
 
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
@@ -21,6 +23,15 @@ public abstract class AbstractFhirService implements FhirService {
 	
 	public IGenericClient getClient() {
 		return client;
+	}
+	
+	/**
+	 * This provides a shortcut to seeing the json for debugging/logging purposes
+	 * @param resource
+	 * @return the resource as json
+	 */
+	protected String resourceAsString(IBaseResource resource) {
+		return client.getFhirContext().newJsonParser().encodeResourceToString(resource);
 	}
 	
 }

--- a/src/main/java/org/octri/hpoonfhir/service/FhirService.java
+++ b/src/main/java/org/octri/hpoonfhir/service/FhirService.java
@@ -1,0 +1,55 @@
+package org.octri.hpoonfhir.service;
+
+import java.util.List;
+
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.exceptions.FHIRException;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+
+/**
+ * The service to query the FHIR server. STU2 and STU3 services set their own context and implement all
+ * service methods, return STU3 entities.
+ */
+public abstract class FhirService {
+	
+	private final String url;
+	private final IGenericClient client;
+	
+	public abstract FhirContext getFhirContext();
+	
+	public FhirService(String url) {
+		this.url = url;
+		getFhirContext().getRestfulClientFactory().setSocketTimeout(30 * 1000); // Extend the timeout
+		client = getFhirContext().newRestfulGenericClient(url);
+	}
+	
+	public String getUrl() {
+		return url;
+	}
+
+	public IGenericClient getClient() {
+		return client;
+	}
+	
+	public String getVersion() {
+		return client.getFhirContext().getVersion().getVersion().name();
+	}
+	
+	/**
+	 * Return a list of patients that loosely match the last name provided.
+	 * @param lastName
+	 * @return the list of patients
+	 */
+	public abstract List<Patient> findPatientsByLastName(String lastName) throws FHIRException;
+
+	/**
+	 * Return a list of patients that loosely match the first and last name provided.
+	 * @param firstName
+	 * @param lastName
+	 * @return the list of patients
+	 */
+	public abstract List<Patient> findPatientsByFullName(String firstName, String lastName) throws FHIRException;
+
+}

--- a/src/main/java/org/octri/hpoonfhir/service/FhirService.java
+++ b/src/main/java/org/octri/hpoonfhir/service/FhirService.java
@@ -5,51 +5,21 @@ import java.util.List;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.exceptions.FHIRException;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.client.api.IGenericClient;
-
 /**
- * The service to query the FHIR server. STU2 and STU3 services set their own context and implement all
- * service methods, return STU3 entities.
+ * The service interface to query the FHIR server. While the underlying server may have a different FHIR version,
+ * the interface expects STU3 objects to be returned.
+ * 
+ * @author yateam
  */
-public abstract class FhirService {
-	
-	private final String url;
-	private final IGenericClient client;
-	
-	public abstract FhirContext getFhirContext();
-	
-	public FhirService(String url) {
-		this.url = url;
-		getFhirContext().getRestfulClientFactory().setSocketTimeout(30 * 1000); // Extend the timeout
-		client = getFhirContext().newRestfulGenericClient(url);
-	}
-	
-	public String getUrl() {
-		return url;
-	}
-
-	public IGenericClient getClient() {
-		return client;
-	}
-	
-	public String getVersion() {
-		return client.getFhirContext().getVersion().getVersion().name();
-	}
-	
-	/**
-	 * Return a list of patients that loosely match the last name provided.
-	 * @param lastName
-	 * @return the list of patients
-	 */
-	public abstract List<Patient> findPatientsByLastName(String lastName) throws FHIRException;
+public interface FhirService {
 
 	/**
-	 * Return a list of patients that loosely match the first and last name provided.
+	 * Return a list of patients that match the first and last name provided.
 	 * @param firstName
 	 * @param lastName
 	 * @return the list of patients
 	 */
-	public abstract List<Patient> findPatientsByFullName(String firstName, String lastName) throws FHIRException;
+	public List<Patient> findPatientsByFullName(String firstName, String lastName) throws FHIRException;
+
 
 }

--- a/src/main/java/org/octri/hpoonfhir/service/Stu2FhirService.java
+++ b/src/main/java/org/octri/hpoonfhir/service/Stu2FhirService.java
@@ -13,8 +13,6 @@ import ca.uhn.fhir.context.FhirContext;
 
 /**
  * The implementation of the STU2 FHIR service. FHIR communication uses STU2 and results are converted to STU3.
- * TODO: Better error handling will be needed, as each FHIR server may respond differently when no results are returned.
- * For example, the Epic Sandbox will not return results based only on a last name. The full name must be provided. 
  * 
  * @author yateam
  *
@@ -36,7 +34,6 @@ public class Stu2FhirService extends AbstractFhirService {
 	@Override
 	public List<Patient> findPatientsByFullName(String firstName, String lastName) throws FHIRException {
 		org.hl7.fhir.instance.model.Bundle patientBundle = getClient().search().forResource(org.hl7.fhir.instance.model.Patient.class).where(Patient.FAMILY.matches().value(lastName)).and(Patient.GIVEN.matches().value(firstName)).returnBundle(org.hl7.fhir.instance.model.Bundle.class).execute();
-		//System.out.println(ctx.newJsonParser().encodeResourceToString(patientBundle));
 		return processPatientBundle(patientBundle);
 		
 	}

--- a/src/main/java/org/octri/hpoonfhir/service/Stu2FhirService.java
+++ b/src/main/java/org/octri/hpoonfhir/service/Stu2FhirService.java
@@ -1,0 +1,70 @@
+package org.octri.hpoonfhir.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hl7.fhir.convertors.NullVersionConverterAdvisor30;
+import org.hl7.fhir.convertors.VersionConvertor_10_30;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.exceptions.FHIRException;
+
+import ca.uhn.fhir.context.FhirContext;
+
+
+/**
+ * The implementation of the STU2 FHIR service. FHIR communication uses STU2 and results are converted to STU3.
+ * TODO: Better error handling will be needed, as each FHIR server may respond differently when no results are returned.
+ * For example, the Epic Sandbox will not return results based only on a last name. The full name must be provided. 
+ * 
+ * @author yateam
+ *
+ */
+public class Stu2FhirService extends FhirService {
+	
+	// This is expensive, so make it static so it's only done once
+	private static final FhirContext ctx = FhirContext.forDstu2Hl7Org();
+	private VersionConvertor_10_30 converter = new VersionConvertor_10_30(new NullVersionConverterAdvisor30());
+
+	public Stu2FhirService(String url) {
+		super(url);
+	}
+
+	@Override
+	public FhirContext getFhirContext() {
+		return ctx;
+	}
+	
+	@Override
+	public List<Patient> findPatientsByLastName(String lastName) throws FHIRException {
+		
+		List<Patient> stu3Patients = new ArrayList<>();
+		org.hl7.fhir.instance.model.Bundle patientBundle = getClient().search().forResource(org.hl7.fhir.instance.model.Patient.class).where(Patient.FAMILY.matches().value(lastName)).returnBundle(org.hl7.fhir.instance.model.Bundle.class).execute();
+		System.out.println(ctx.newJsonParser().encodeResourceToString(patientBundle));
+		
+		for (org.hl7.fhir.instance.model.Bundle.BundleEntryComponent bundleEntryComponent: patientBundle.getEntry()) {
+			org.hl7.fhir.instance.model.Patient stu2Patient = (org.hl7.fhir.instance.model.Patient) bundleEntryComponent.getResource();
+			Patient stu3Patient = (Patient) converter.convertPatient(stu2Patient);
+			stu3Patients.add(stu3Patient);
+		}
+
+		return stu3Patients;
+	}
+
+	@Override
+	public List<Patient> findPatientsByFullName(String firstName, String lastName) throws FHIRException {
+		List<Patient> stu3Patients = new ArrayList<>();
+		// TODO: Try a traditional search not by url
+		org.hl7.fhir.instance.model.Bundle patientBundle = getClient().search().byUrl("Patient?family=" + lastName + "&given=" + firstName).returnBundle(org.hl7.fhir.instance.model.Bundle.class).execute();
+		System.out.println(ctx.newJsonParser().encodeResourceToString(patientBundle));
+		
+		for (org.hl7.fhir.instance.model.Bundle.BundleEntryComponent bundleEntryComponent: patientBundle.getEntry()) {
+			org.hl7.fhir.instance.model.Patient stu2Patient = (org.hl7.fhir.instance.model.Patient) bundleEntryComponent.getResource();
+			Patient stu3Patient = (Patient) converter.convertPatient(stu2Patient);
+			stu3Patients.add(stu3Patient);
+		}
+
+		return stu3Patients;
+	}
+
+
+}

--- a/src/main/java/org/octri/hpoonfhir/service/Stu3FhirService.java
+++ b/src/main/java/org/octri/hpoonfhir/service/Stu3FhirService.java
@@ -1,5 +1,6 @@
 package org.octri.hpoonfhir.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -16,9 +17,8 @@ import ca.uhn.fhir.context.FhirContext;
  * @author yateam
  *
  */
-public class Stu3FhirService extends FhirService {
+public class Stu3FhirService extends AbstractFhirService {
 	
-	// This is expensive, so make it static so it's only done once
 	private static final FhirContext ctx = FhirContext.forDstu3();
 
 	public Stu3FhirService(String url) {
@@ -31,15 +31,17 @@ public class Stu3FhirService extends FhirService {
 	}
 	
 	@Override
-	public List<Patient> findPatientsByLastName(String lastName) throws FHIRException {
-		Bundle patientBundle = getClient().search().forResource(Patient.class).where(Patient.FAMILY.matches().value(lastName)).returnBundle(Bundle.class).execute();
-		return patientBundle.getEntry().stream().map(bundleEntryComponent -> (Patient) bundleEntryComponent.getResource()).collect(Collectors.toList());
-	}
-
-	@Override
 	public List<Patient> findPatientsByFullName(String firstName, String lastName) throws FHIRException {
 		Bundle patientBundle = getClient().search().forResource(Patient.class).where(Patient.FAMILY.matches().value(lastName)).and(Patient.GIVEN.matches().value(firstName)).returnBundle(Bundle.class).execute();
-		return patientBundle.getEntry().stream().map(bundleEntryComponent -> (Patient) bundleEntryComponent.getResource()).collect(Collectors.toList());
+		return processPatientBundle(patientBundle);
+	}
+	
+	private List<Patient> processPatientBundle(Bundle patientBundle) {
+		if (!patientBundle.hasTotal() || patientBundle.getTotal() > 0) {
+			return patientBundle.getEntry().stream().map(bundleEntryComponent -> (Patient) bundleEntryComponent.getResource()).collect(Collectors.toList());
+		}
+		
+		return new ArrayList<>();
 	}
 
 }

--- a/src/main/java/org/octri/hpoonfhir/service/Stu3FhirService.java
+++ b/src/main/java/org/octri/hpoonfhir/service/Stu3FhirService.java
@@ -1,0 +1,45 @@
+package org.octri.hpoonfhir.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.exceptions.FHIRException;
+
+import ca.uhn.fhir.context.FhirContext;
+
+
+/**
+ * The implementation of the STU3 FHIR service. No conversions are necessary.
+ * 
+ * @author yateam
+ *
+ */
+public class Stu3FhirService extends FhirService {
+	
+	// This is expensive, so make it static so it's only done once
+	private static final FhirContext ctx = FhirContext.forDstu3();
+
+	public Stu3FhirService(String url) {
+		super(url);
+	}
+
+	@Override
+	public FhirContext getFhirContext() {
+		return ctx;
+	}
+	
+	@Override
+	public List<Patient> findPatientsByLastName(String lastName) throws FHIRException {
+		Bundle patientBundle = getClient().search().forResource(Patient.class).where(Patient.FAMILY.matches().value(lastName)).returnBundle(Bundle.class).execute();
+		return patientBundle.getEntry().stream().map(bundleEntryComponent -> (Patient) bundleEntryComponent.getResource()).collect(Collectors.toList());
+	}
+
+	@Override
+	public List<Patient> findPatientsByFullName(String firstName, String lastName) throws FHIRException {
+		Bundle patientBundle = getClient().search().forResource(Patient.class).where(Patient.FAMILY.matches().value(lastName)).and(Patient.GIVEN.matches().value(firstName)).returnBundle(Bundle.class).execute();
+		return patientBundle.getEntry().stream().map(bundleEntryComponent -> (Patient) bundleEntryComponent.getResource()).collect(Collectors.toList());
+	}
+
+}

--- a/src/main/java/org/octri/hpoonfhir/view/PatientModel.java
+++ b/src/main/java/org/octri/hpoonfhir/view/PatientModel.java
@@ -1,0 +1,40 @@
+package org.octri.hpoonfhir.view;
+
+/**
+ * The model representing the fields we care about when search for and displaying a patient
+ * 
+ * @author yateam
+ *
+ */
+public class PatientModel {
+
+	
+	private String id;
+	private String firstName;
+	private String lastName;
+	
+	public String getId() {
+		return id;
+	}
+	
+	public void setId(String id) {
+		this.id = id;
+	}
+	
+	public String getFirstName() {
+		return firstName;
+	}
+	
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+	
+	public String getLastName() {
+		return lastName;
+	}
+	
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+}

--- a/src/main/java/org/octri/hpoonfhir/view/PatientModel.java
+++ b/src/main/java/org/octri/hpoonfhir/view/PatientModel.java
@@ -13,6 +13,16 @@ public class PatientModel {
 	private String firstName;
 	private String lastName;
 	
+	public PatientModel() {
+		
+	}
+	
+	public PatientModel(String id, String firstName, String lastName) {
+		this.id = id;
+		this.firstName = firstName;
+		this.lastName = lastName;
+	}
+	
 	public String getId() {
 		return id;
 	}

--- a/src/main/resources/mustache-templates/annotations.html
+++ b/src/main/resources/mustache-templates/annotations.html
@@ -2,9 +2,9 @@
 
 <div class="container vertical-space">
 	<ul>
-		{{#loincMap}}
-			<li><a href="/hpo?loinc_id={{key}}">{{key}}</a></li>
-		{{/loincMap}}
+		{{#loincs}}
+			<li><a href="/hpo?loinc_id={{.}}">{{.}}</a></li>
+		{{/loincs}}
 	</ul>
 </div>
 

--- a/src/main/resources/mustache-templates/search.html
+++ b/src/main/resources/mustache-templates/search.html
@@ -7,16 +7,16 @@
 	<form method="POST" action="{{req.contextPath}}/search">
 		{{#patientSearchForm}}
 		<div class="form-group row vertical-space">
-			<label for="first_name" class="col-sm-2 col-form-label">First Name</label>
+			<label for="firstName" class="col-sm-2 col-form-label">First Name</label>
 			<div class="col-sm-4">
-				<input class='form-control' type='text' name='firstName' value='{{#firstName}}{{.}}{{/firstName}}' />
+				<input class="form-control" type="text" name="firstName" value="{{#firstName}}{{.}}{{/firstName}}" />
 			</div>
 			<div class="col-sm-6"></div>
 		</div>
 		<div class="form-group row">
-			<label for="last_name" class="col-sm-2 col-form-label">Last Name</label>
+			<label for="lastName" class="col-sm-2 col-form-label">Last Name</label>
 			<div class="col-sm-4">
-				<input class='form-control' type='text' name='lastName' value='{{#lastName}}{{.}}{{/lastName}}' />
+				<input class="form-control" type="text" name="lastName" value="{{#lastName}}{{.}}{{/lastName}}" />
 			</div>
 			<div class="col-sm-6"></div>
 		</div>

--- a/src/main/resources/mustache-templates/search.html
+++ b/src/main/resources/mustache-templates/search.html
@@ -40,11 +40,13 @@
 			{{^patients}}
 				<p>No Results Found</p>
 			{{/patients}}
+			<ul>
 			{{#patients}}
-				<div class="row" style="margin-left:inherit;">
-					<a href="{{req.contextPath}}/labs?patient_id={{id}}">{{firstName}} {{lastName}} ({{id}})</a>
-				</div>
+			<li>
+				<a href="{{req.contextPath}}/labs?patient_id={{id}}">{{firstName}} {{lastName}} ({{id}})</a>
+			</li>
 			{{/patients}}
+			</ul>
 		</div>
 	{{/results}}	
 </div>

--- a/src/main/resources/mustache-templates/search.html
+++ b/src/main/resources/mustache-templates/search.html
@@ -2,29 +2,25 @@
 
 
 <div class="container vertical-space">
-	<h4>Patient Search</h4>
-	<small class="text-muted">Search the EHR system for a patient.
-		Click on the patient to see their labs and HPO terms.</small>
-	<form role="form" class="form" method="GET"
-		enctype="multipart/form-data" action="{{req.contextPath}}/search/">
+	<h3>Patient Search</h3>
+	<small class="text-muted">Search the EHR system for a patient.</small>
+	<form method="POST" action="{{req.contextPath}}/search">
+		{{#patientSearchForm}}
 		<div class="form-group row vertical-space">
-			<label for="first_name" class="col-sm-2 col-form-label">First
-				Name</label>
+			<label for="first_name" class="col-sm-2 col-form-label">First Name</label>
 			<div class="col-sm-4">
-				<input id="first_name" class="form-control" type="text"
-					name="first_name" />
+				<input class='form-control' type='text' name='firstName' value='{{#firstName}}{{.}}{{/firstName}}' />
 			</div>
 			<div class="col-sm-6"></div>
 		</div>
 		<div class="form-group row">
-			<label for="last_name" class="col-sm-2 col-form-label">Last
-				Name</label>
+			<label for="last_name" class="col-sm-2 col-form-label">Last Name</label>
 			<div class="col-sm-4">
-				<input id="last_name" class="form-control" type="text"
-					name="last_name" />
+				<input class='form-control' type='text' name='lastName' value='{{#lastName}}{{.}}{{/lastName}}' />
 			</div>
 			<div class="col-sm-6"></div>
 		</div>
+		{{/patientSearchForm}}
 		<div class="form-group row vertical-space">
 			<div class="col-sm-6">
 				<button type="submit" class="btn btn-primary">Submit</button>
@@ -36,49 +32,21 @@
 </div>
 
 <div class="container">
-	<ul id="patient_list">
-	</ul>
-	<p id="no-results" hidden="true">No Results Found</p>
+	{{#results}}
+		<h3>Search Results</h3>
+		<small class="text-muted">
+		Click on the patient to see their labs and HPO terms.</small>
+		<div class="vertical-space">
+			{{^patients}}
+				<p>No Results Found</p>
+			{{/patients}}
+			{{#patients}}
+				<div class="row" style="margin-left:inherit;">
+					<a href="{{req.contextPath}}/labs?patient_id={{id}}">{{firstName}} {{lastName}} ({{id}})</a>
+				</div>
+			{{/patients}}
+		</div>
+	{{/results}}	
 </div>
 
-<script type="text/javascript"
-	src="{{req.contextPath}}/webjars/jquery/1.12.4/jquery.min.js"></script>
-<script type="text/javascript"
-	src="{{req.contextPath}}/js/fhir-client.js"></script>
-<script type="text/javascript">
-	var demo = {
-		serviceUrl : "https://r3.smarthealthit.org"
-	};
-
-	// Create a FHIR client
-	var smart = FHIR.client(demo);
-	$(".form").submit(function(event) {
-		event.preventDefault();
-		let lastName = $("#last_name").val();
-		if (lastName.length > 1) {
-			$("#patient_list").html("");
-			smart.api.search({type : "Patient", query: {family: lastName}}).then(function(bundle) {
-				if (bundle.data.total > 0) {
-					$("#no-results").attr("hidden", true);
-					let patients = bundle.data.entry.map(e => { 
-						return {id: e.resource.id, name: e.resource.name[0].given[0] + " " + e.resource.name[0].family};
-					});
-					patients.forEach(pt => {
-						let id = pt.id;
-						document.getElementById("patient_list").innerHTML += 
-							"<li><a id=\"" + id + "\" href=\"labs?patient_id=" + id + "\" onclick=\"displayLabs('" + id + "')\">" + pt.name + "</a></li>";
-					});
-				} else {
-					$("#no-results").attr("hidden", false);
-				}
-			});
-		}
-	});
-	
-	function displayLabs(id) {
-		
-		console.log(id);
-	}
-	
-</script>
 {{>layout/footer}}


### PR DESCRIPTION
* Added FHIR services for STU2 and STU3 communication
* Configured 2 sandboxes. Only one is active at a time.
* Implemented patient search by first/last name

This does not fully remove the dependency on the jsclient for FHIR. It is still being used to find labs. The branch was getting large, and this seemed like a good stopping point.