### PR TITLE
Convert to Spring Boot 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.10.RELEASE</version>
+		<version>2.0.3.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -29,21 +29,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>jul-to-slf4j</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>ch.qos.logback</groupId>
-					<artifactId>logback-classic</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -52,6 +37,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mustache</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -78,7 +68,7 @@
 		    <artifactId>datatables</artifactId>
 		    <version>1.10.19</version>
 		</dependency>
-		<dependency>
+ 		<dependency>
 			<groupId>org.monarchinitiative</groupId>
 			<artifactId>fhir2hpo</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
@@ -116,12 +106,6 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-converter</artifactId>
 			<version>3.4.0</version>
-		</dependency>
-		<!-- Required to work with LogManager in fhir2hpo dependency -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.11.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,9 +3,14 @@ app.version=@project.version@
 app.displayName=HPO on FHIR
 spring.devtools.livereload.enabled=${SPRING_DEVTOOLS_LIVERELOAD_ENABLED:false}
 
-server.context-path=${SERVER_CONTEXT_PATH:/}
+server.servlet.context-path=${SERVER_CONTEXT_PATH:/}
 server.port=${SERVER_PORT:8080}
 
 spring.mustache.prefix=classpath:/mustache-templates/
+spring.mustache.suffix=.html
 spring.mustache.expose-request-attributes=true
 spring.mustache.request-context-attribute=req
+
+logging.level.org.springframework=WARN
+logging.level.org.monarchinitiative.phenol=ERROR
+logging.level.org.obolibrary=ERROR


### PR DESCRIPTION
The previous logging configuration kept Spring Boot 2 from starting the web application and provided no info (since it couldn't log anything!). I removed all of the special things I was doing to work with the LogManager dictated by the original library. Everything seems to work fine now, but is very verbose. So I added some configuration to application.properties to quiet it.

https://stackoverflow.com/questions/45919310/spring-boot-1-5-2-web-application-stops-after-loading-logo