### PR TITLE
Add a meta tag for JS reads of context path.

### DIFF
--- a/src/main/resources/mustache-templates/layout/header.html
+++ b/src/main/resources/mustache-templates/layout/header.html
@@ -3,6 +3,7 @@
 
 <title>HPO on FHIR</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<meta name="ctx" content="{{req.contextPath}}/"/>
 <link rel="stylesheet" type="text/css"
 	href="{{req.contextPath}}/webjars/bootstrap/css/bootstrap.min.css" />
 <link rel="stylesheet" type="text/css" href="{{req.contextPath}}/webjars/datatables/css/dataTables.bootstrap4.min.css">

--- a/src/main/resources/static/js/hposummary.js
+++ b/src/main/resources/static/js/hposummary.js
@@ -2,8 +2,8 @@
 
 $(document).ready(function() {
 	
-	function getContextPath() {		
-		return '/' + window.location.pathname.split('/')[1];
+	function getContextPath() {
+		return $("meta[name='ctx']").attr("content");
 	}
 	
 	function showLabs(d) {
@@ -31,7 +31,7 @@ $(document).ready(function() {
 	// Set up table
 	let table = $("#hposummary").DataTable({
 		ajax : {
-			"url" : getContextPath() + "/" + patientId + "/summary"
+			"url" : getContextPath() + "patient/" + patientId + "/summary"
 		},
 		info: true,
 		paging : true,


### PR DESCRIPTION
This works with no context path. Waiting to test the Epic App with context path hpo_on_fhir.