### PR TITLE
CIS-1010 Java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ logs/*
 /dist/
 /nbdist/
 /.nb-gradle/
+
+### Docker
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,9 @@
 version: "2"
 services:
   app:
-    image: octri.ohsu.edu/jarrunner:2018q4
+    image: octri.ohsu.edu/jarrunner:2019q2
+    ports:
+      - 8080:8080
     volumes:
       - ./target/hpoOnFhir.jar:/app.jar
     environment:

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<fhir2hpo.version>1.0.1</fhir2hpo.version>
+		<fhir2hpo.version>1.0.2-SNAPSHOT</fhir2hpo.version>
 		<hapi.version>3.4.0</hapi.version>
 	</properties>
 
@@ -37,6 +37,10 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mustache</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-log4j2</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -116,6 +120,33 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-converter</artifactId>
 			<version>${hapi.version}</version>
+		</dependency>
+
+		<!-- Java 11 Dependencies -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.26</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>2.8.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.8.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.8.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-jcl</artifactId>
+			<version>2.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<fhir2hpo.version>1.0.2-SNAPSHOT</fhir2hpo.version>
+		<fhir2hpo.version>1.0.1</fhir2hpo.version>
 		<hapi.version>3.4.0</hapi.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<fhir2hpo.version>1.0.1</fhir2hpo.version>
+		<fhir2hpo.version>1.0.2</fhir2hpo.version>
 		<hapi.version>3.4.0</hapi.version>
 	</properties>
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" monitorInterval="30">
+    <Properties>
+        <Property name="LOG_PATTERN">
+            %d{yyyy-MM-dd HH:mm:ss.SSS} %5p ${hostName} --- [%15.15t] %-40.40c{1.} : %m%n%ex
+        </Property>
+    </Properties>
+    <Appenders>
+        <Console name="ConsoleAppender" target="SYSTEM_OUT" follow="true">
+            <PatternLayout pattern="${LOG_PATTERN}"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.octri.hpoonfhir" level="debug" additivity="false">
+            <AppenderRef ref="ConsoleAppender" />
+        </Logger>
+
+        <Root level="info">
+            <AppenderRef ref="ConsoleAppender" />
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Add log4j 2 dependencies.

Add log4j2.xml. The presence of this file triggers log4j2 to load as far as I know. We can tweak the logging as needed, this is just a base configuration.

Expose 8080 for running locally under Docker.