### PR TITLE
CIS-1058 update image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "2"
 services:
   app:
-    image: octri.ohsu.edu/jarrunner:2019q2
+    image: octri.ohsu.edu/jarrunner:11
     ports:
       - 8080:8080
     volumes:


### PR DESCRIPTION
Here's another one. Upgrade to the new docker library `jarrunner:11` image.