### PR TITLE
CIS-1058 use jarrunner:8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "2"
 services:
   app:
-    image: octri.ohsu.edu/jarrunner:11
+    image: octri.ohsu.edu/jarrunner:8
     ports:
       - 8080:8080
     volumes:


### PR DESCRIPTION
Amy, this should have been `jarrunner:8`, not `11`. At least it's currently running on v8. I'm going to go ahead and merge since you're out so I can get it deployed.