### PR TITLE
Upgrade/Add ability to report phenotype discoveries back to FHIR server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<fhir2hpo.version>1.0.3</fhir2hpo.version>
-		<hapi.version>3.8.0</hapi.version>
+		<fhir2hpo.version>1.0.4-SNAPSHOT</fhir2hpo.version>
+		<hapi.version>5.2.0</hapi.version>
 	</properties>
 
 	<dependencies>
@@ -95,6 +95,25 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-hl7org-dstu2</artifactId>
+			<version>${hapi.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-io</groupId>
+					<artifactId>commons-io</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-codec</groupId>
+					<artifactId>commons-codec</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-structures-dstu3</artifactId>
 			<version>${hapi.version}</version>
 			<exclusions>
 				<exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<fhir2hpo.version>1.0.4-SNAPSHOT</fhir2hpo.version>
+		<fhir2hpo.version>1.0.5-SNAPSHOT</fhir2hpo.version>
 		<hapi.version>5.2.0</hapi.version>
 	</properties>
 

--- a/src/main/java/org/octri/hpoonfhir/controller/MainController.java
+++ b/src/main/java/org/octri/hpoonfhir/controller/MainController.java
@@ -1,14 +1,22 @@
 package org.octri.hpoonfhir.controller;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.model.Annotation;
+import org.hl7.fhir.r5.model.BooleanType;
+import org.hl7.fhir.r5.model.CodeableConcept;
+import org.hl7.fhir.r5.model.Identifier;
+import org.hl7.fhir.r5.model.Observation;
+import org.hl7.fhir.r5.model.Patient;
+import org.hl7.fhir.r5.model.Reference;
 import org.monarchinitiative.fhir2hpo.loinc.DefaultLoinc2HpoAnnotation;
 import org.monarchinitiative.fhir2hpo.loinc.Loinc2HpoAnnotation;
 import org.monarchinitiative.fhir2hpo.loinc.LoincId;
@@ -19,7 +27,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class MainController {
@@ -43,9 +53,14 @@ public class MainController {
 		List<PatientModel> patientModels = new ArrayList<>();
 		
 		try {
-			patientModels.add(new PatientModel(fhirService.findPatientById("smart-1627321")));
-			patientModels.add(new PatientModel(fhirService.findPatientById("smart-1134281")));
-			patientModels.add(new PatientModel(fhirService.findPatientById("smart-8888803")));
+			List<Patient> fhirPatients = fhirService.findPatientsByFullName("John", "McLean");
+			if (fhirPatients.size() > 1) {
+				patientModels.add(new PatientModel(fhirPatients.get(0)));
+			}
+			//patientModels.add(new PatientModel(fhirService.findPatientById("1505")));
+			//patientModels.add(new PatientModel(fhirService.findPatientById("1652")));
+			//patientModels.add(new PatientModel(fhirService.findPatientById("863165")));
+			//patientModels.add(new PatientModel(fhirService.findPatientById("JHU473711")));
 		} catch (FHIRException e) {
 			// Do nothing. Assume something's wrong with the sandbox and display a message indicating this.
 			e.printStackTrace();
@@ -95,5 +110,57 @@ public class MainController {
 
 		return "hpo";
 	}
+	
+	@PostMapping("/reportHpo")
+	public String reportHpo(Map<String, Object> model, @RequestParam String patientId, 
+			@RequestParam String hpoTermId, @RequestParam String hpoTermName, 
+			@RequestParam String observations, @RequestParam String comments) {
 
+		Observation hpoObservation = new Observation();
+		hpoObservation.setId(String.valueOf(new Random().nextLong()));
+		// TODO: Temp
+		hpoObservation.setId("1673");
+		
+		Identifier identifier = new Identifier().setSystem("http://hpo.jax.org").setValue(patientId + "|" + hpoTermId);
+		hpoObservation.getIdentifier().add(identifier);
+		
+		hpoObservation
+			.getCode()
+			.addCoding()
+			.setSystem("http://hpo.jax.org")
+			.setCode(hpoTermId)
+			.setDisplay(hpoTermName);
+        BooleanType btype = new BooleanType(true);
+        hpoObservation.setValue(btype);
+        
+        // Get the patient from the FHIR server
+        Patient patient = fhirService.findPatientById(patientId);
+        Reference patientReference = new Reference(patient);
+        hpoObservation.setSubject(patientReference);
+
+        // Parse the observation ids, and get the corresponding observations from FHIR server
+		List<String> observationIds = Arrays.asList(observations.split(","));
+		for (String observationId : observationIds) {
+			Observation origObservation = fhirService.findObservationById(observationId);
+			Reference reference = new Reference(origObservation);
+			hpoObservation.getDerivedFrom().add(reference);
+		}
+
+        // Add the comment as a note
+		Annotation annotation = new Annotation();
+        annotation.setText(comments);
+        hpoObservation.getNote().add(annotation);
+        
+        // Add a custom category - may be able to query with this
+        CodeableConcept category = new CodeableConcept();
+        category.addCoding("http://hpo.jax.org", "hpo", "HPO");
+        hpoObservation.getCategory().add(category);
+        
+        fhirService.createUpdateObservation(hpoObservation);
+
+		return "redirect:/patient/" + patientId;
+	}
+
+
+	
 }

--- a/src/main/java/org/octri/hpoonfhir/controller/PhenotypeSummaryController.java
+++ b/src/main/java/org/octri/hpoonfhir/controller/PhenotypeSummaryController.java
@@ -52,5 +52,4 @@ public class PhenotypeSummaryController {
 		return json;
 	}
 
-
 }

--- a/src/main/java/org/octri/hpoonfhir/service/FhirService.java
+++ b/src/main/java/org/octri/hpoonfhir/service/FhirService.java
@@ -2,8 +2,8 @@ package org.octri.hpoonfhir.service;
 
 import java.util.List;
 
-import org.hl7.fhir.dstu3.model.Observation;
-import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.r5.model.Observation;
+import org.hl7.fhir.r5.model.Patient;
 import org.hl7.fhir.exceptions.FHIRException;
 
 /**
@@ -37,10 +37,33 @@ public interface FhirService {
 	public List<Patient> findPatientsByFullName(String firstName, String lastName) throws FHIRException;
 
 	/**
+	 * 
+	 * @param id
+	 * @return
+	 * @throws FHIRException
+	 */
+	Observation findObservationById(String id) throws FHIRException;
+
+	/**
 	 * Return the observations for the given patient id.
 	 * @param patientId
 	 * @return the list of observations
 	 */
 	public List<Observation> findObservationsForPatient(String patientId) throws FHIRException;
+
+	/**
+	 * Create or update a patient
+	 * @param patient
+	 * @return
+	 * @throws FHIRException
+	 */
+	public Patient createUpdatePatient(Patient patient) throws FHIRException;
+
+	/**
+	 * Create or update an observation
+	 * @param observation
+	 * @return
+	 */
+	public Observation createUpdateObservation(Observation observation) throws FHIRException;
 
 }

--- a/src/main/java/org/octri/hpoonfhir/service/FhirServiceBuilder.java
+++ b/src/main/java/org/octri/hpoonfhir/service/FhirServiceBuilder.java
@@ -6,12 +6,15 @@ public class FhirServiceBuilder {
 	
 	public static final String STU2_VERSION = "STU2";
 	public static final String STU3_VERSION = "STU3";
+	public static final String R5_VERSION = "R5";
 	
 	public static FhirService build(FhirConfig config) {
 		if (config.getVersion().equals(STU2_VERSION)) {
 			return new Stu2FhirService(config.getName(), config.getUrl());
 		} else if (config.getVersion().equals(STU3_VERSION)) {
 			return new Stu3FhirService(config.getName(), config.getUrl());
+		} else if (config.getVersion().equals(R5_VERSION)) {
+			return new R5FhirService(config.getName(), config.getUrl());
 		}
 		
 		throw new IllegalArgumentException("The FHIR version " + config.getVersion() + " is not supported.");

--- a/src/main/java/org/octri/hpoonfhir/service/R5FhirService.java
+++ b/src/main/java/org/octri/hpoonfhir/service/R5FhirService.java
@@ -1,0 +1,117 @@
+package org.octri.hpoonfhir.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.model.Bundle;
+import org.hl7.fhir.r5.model.Observation;
+import org.hl7.fhir.r5.model.Patient;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.gclient.ReferenceClientParam;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+
+
+/**
+ * The implementation of the R5 FHIR service. No conversions are necessary.
+ * 
+ * @author yateam
+ *
+ */
+public class R5FhirService extends AbstractFhirService {
+	
+	private static final FhirContext ctx = FhirContext.forR5();
+
+	public R5FhirService(String serviceName, String url) {
+		super(serviceName, url);
+	}
+
+	@Override
+	public FhirContext getFhirContext() {
+		return ctx;
+	}
+	
+	@Override
+	public Patient findPatientById(String id) throws FHIRException {
+		try {
+			//TODO: AEY This has to be parsed as a long to work with the HAPI FHIR server cause dumb.
+			return getClient().read().resource(Patient.class).withId(Long.parseLong(id)).execute();
+		} catch(ResourceNotFoundException e) {
+			return null;
+		}
+	}
+
+	@Override
+	public List<Patient> findPatientsByFullName(String firstName, String lastName) throws FHIRException {
+		//TODO: Check for a next link and more bundles
+		Bundle patientBundle = getClient().search().forResource(Patient.class).where(Patient.FAMILY.matches().value(lastName)).and(Patient.GIVEN.matches().value(firstName)).returnBundle(Bundle.class).execute();
+		return processPatientBundle(patientBundle);
+	}
+	
+	@Override
+	public Observation findObservationById(String id) throws FHIRException {
+		try {
+			//TODO: AEY This has to be parsed as a long to work with the HAPI FHIR server cause dumb.
+			return getClient().read().resource(Observation.class).withId(Long.parseLong(id)).execute();
+		} catch(ResourceNotFoundException e) {
+			return null;
+		}
+	}
+
+	@Override
+	public List<Observation> findObservationsForPatient(String patientId) throws FHIRException {
+		List<Observation> allObservations = new ArrayList<>();
+		Bundle observationBundle = getClient().search().forResource(Observation.class).where(new ReferenceClientParam("patient").hasId(patientId)).returnBundle(Bundle.class).execute();
+		
+		while (observationBundle != null) {
+			allObservations.addAll(processObservationBundle(observationBundle));
+			observationBundle = (observationBundle.getLink(Bundle.LINK_NEXT) != null) ? getClient().loadPage().next(observationBundle).execute() : null;
+		}
+		
+		return allObservations;
+	}
+
+	private List<Patient> processPatientBundle(Bundle patientBundle) {
+		if (!patientBundle.hasTotal() || patientBundle.getTotal() > 0) {
+			return patientBundle.getEntry().stream().map(bundleEntryComponent -> (Patient) bundleEntryComponent.getResource()).collect(Collectors.toList());
+		}
+		
+		return new ArrayList<>();
+	}
+
+	private List<Observation> processObservationBundle(Bundle observationBundle) {
+		if (!observationBundle.hasTotal() || observationBundle.getTotal() > 0) {
+			return observationBundle.getEntry().stream().map(bundleEntryComponent -> (Observation) bundleEntryComponent.getResource()).collect(Collectors.toList());
+		}
+		
+		return new ArrayList<>();
+	}
+	
+	@Override
+	public Patient createUpdatePatient(Patient patient) throws FHIRException {
+		Patient found = findPatientById(patient.getIdElement().getIdPart());
+		if (found != null) {
+			MethodOutcome outcome = getClient().update().resource(patient).execute();
+			return (Patient) outcome.getResource();
+		}
+		
+		MethodOutcome outcome = getClient().create().resource(patient).execute();
+		return (Patient) outcome.getResource();
+	}
+
+	@Override
+	public Observation createUpdateObservation(Observation observation) throws FHIRException {
+		Observation found = findObservationById(observation.getIdElement().getIdPart());
+		if (found != null) {
+			MethodOutcome outcome = getClient().update().resource(observation).execute();
+			return (Observation) outcome.getResource();
+		}
+		
+		MethodOutcome outcome = getClient().create().resource(observation).execute();
+		return (Observation) outcome.getResource();
+	}
+
+}

--- a/src/main/java/org/octri/hpoonfhir/service/Stu3FhirService.java
+++ b/src/main/java/org/octri/hpoonfhir/service/Stu3FhirService.java
@@ -2,15 +2,15 @@ package org.octri.hpoonfhir.service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Observation;
-import org.hl7.fhir.dstu3.model.Patient;
+import org.apache.commons.lang3.NotImplementedException;
+import org.hl7.fhir.convertors.VersionConvertor_30_50;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.model.Bundle;
+import org.hl7.fhir.r5.model.Observation;
+import org.hl7.fhir.r5.model.Patient;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.gclient.ReferenceClientParam;
 
 
 /**
@@ -34,20 +34,29 @@ public class Stu3FhirService extends AbstractFhirService {
 	
 	@Override
 	public Patient findPatientById(String id) throws FHIRException {
-		return getClient().read().resource(Patient.class).withId(id).execute();
+		org.hl7.fhir.dstu3.model.Patient stu3Patient = getClient().read().resource(org.hl7.fhir.dstu3.model.Patient.class).withId(id).execute();		
+		return (Patient) VersionConvertor_30_50.convertResource(stu3Patient, true);
 	}
 
 	@Override
 	public List<Patient> findPatientsByFullName(String firstName, String lastName) throws FHIRException {
-		//TODO: Check for a next link and more bundles
-		Bundle patientBundle = getClient().search().forResource(Patient.class).where(Patient.FAMILY.matches().value(lastName)).and(Patient.GIVEN.matches().value(firstName)).returnBundle(Bundle.class).execute();
+		org.hl7.fhir.dstu3.model.Bundle patientBundle = getClient().search().forResource(org.hl7.fhir.dstu3.model.Patient.class).where(Patient.FAMILY.matches().value(lastName)).and(Patient.GIVEN.matches().value(firstName)).returnBundle(org.hl7.fhir.dstu3.model.Bundle.class).execute();
 		return processPatientBundle(patientBundle);
+		
 	}
 	
 	@Override
+	public Observation findObservationById(String id) throws FHIRException {
+		throw new NotImplementedException("Only available on R5 servers");
+	}
+
+	@Override
 	public List<Observation> findObservationsForPatient(String patientId) throws FHIRException {
 		List<Observation> allObservations = new ArrayList<>();
-		Bundle observationBundle = getClient().search().forResource(Observation.class).where(new ReferenceClientParam("patient").hasId(patientId)).returnBundle(Bundle.class).execute();
+		// Epic sandbox query will fail if category is not provided
+		org.hl7.fhir.dstu3.model.Bundle observationBundle = getClient().search()
+				.byUrl("Observation?patient=" + patientId + "&category=vital-signs,laboratory")
+				.returnBundle(org.hl7.fhir.dstu3.model.Bundle.class).execute();
 		
 		while (observationBundle != null) {
 			allObservations.addAll(processObservationBundle(observationBundle));
@@ -57,20 +66,40 @@ public class Stu3FhirService extends AbstractFhirService {
 		return allObservations;
 	}
 
-	private List<Patient> processPatientBundle(Bundle patientBundle) {
+	private List<Patient> processPatientBundle(org.hl7.fhir.dstu3.model.Bundle patientBundle) throws FHIRException {
+		List<Patient> upgradedPatients = new ArrayList<>();
 		if (!patientBundle.hasTotal() || patientBundle.getTotal() > 0) {
-			return patientBundle.getEntry().stream().map(bundleEntryComponent -> (Patient) bundleEntryComponent.getResource()).collect(Collectors.toList());
+			for (org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent bundleEntryComponent: patientBundle.getEntry()) {
+				org.hl7.fhir.dstu3.model.Patient stu3Patient = (org.hl7.fhir.dstu3.model.Patient) bundleEntryComponent.getResource();
+				Patient upgradedPatient = (Patient) VersionConvertor_30_50.convertResource(stu3Patient, true);
+				upgradedPatients.add(upgradedPatient);
+			}
 		}
-		
-		return new ArrayList<>();
+
+		return upgradedPatients;		
 	}
 
-	private List<Observation> processObservationBundle(Bundle observationBundle) {
+	private List<Observation> processObservationBundle(org.hl7.fhir.dstu3.model.Bundle observationBundle) throws FHIRException {
+		List<Observation> upgradedObservations = new ArrayList<>();
 		if (!observationBundle.hasTotal() || observationBundle.getTotal() > 0) {
-			return observationBundle.getEntry().stream().map(bundleEntryComponent -> (Observation) bundleEntryComponent.getResource()).collect(Collectors.toList());
+			for (org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent bundleEntryComponent: observationBundle.getEntry()) {
+				org.hl7.fhir.dstu3.model.Observation stu3Observation = (org.hl7.fhir.dstu3.model.Observation) bundleEntryComponent.getResource();
+				Observation upgradedObservation = (Observation) VersionConvertor_30_50.convertResource(stu3Observation, true);
+				upgradedObservations.add(upgradedObservation);
+			}
 		}
 		
-		return new ArrayList<>();
+		return upgradedObservations;		
+	}
+
+	@Override
+	public Patient createUpdatePatient(Patient patient) throws FHIRException {
+		throw new NotImplementedException("Only available on R5 servers");
+	}
+
+	@Override
+	public Observation createUpdateObservation(Observation observation) throws FHIRException {
+		throw new NotImplementedException("Only available on R5 servers");
 	}
 
 }

--- a/src/main/java/org/octri/hpoonfhir/view/ObservationModel.java
+++ b/src/main/java/org/octri/hpoonfhir/view/ObservationModel.java
@@ -22,8 +22,9 @@ public class ObservationModel implements Serializable {
 	private final String startDate;
 	private final String endDate;
 	private final String value;
+	private final Boolean reported;
 
-	public ObservationModel(String loincId, ObservationLoincInfo observationLoincInfo) {
+	public ObservationModel(String loincId, ObservationLoincInfo observationLoincInfo, Boolean reported) {
 		DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
 		this.fhirId = observationLoincInfo.getFhirId();
 		this.loincId = loincId;
@@ -31,7 +32,7 @@ public class ObservationModel implements Serializable {
 		this.startDate = observationLoincInfo.getStartDate().map(d -> df.format(d)).orElse("");
 		this.endDate = observationLoincInfo.getEndDate().map(d -> df.format(d)).orElse("");
 		this.value = observationLoincInfo.getValueDescription();
-
+		this.reported = reported;
 	}
 
 	/**
@@ -80,6 +81,14 @@ public class ObservationModel implements Serializable {
 	 */
 	public String getValue() {
 		return value;
+	}
+
+	/**
+	 * Whether this specific Observation has had the HPO Term reported back to the server
+	 * @return
+	 */
+	public Boolean getReported() {
+		return reported;
 	}
 
 }

--- a/src/main/java/org/octri/hpoonfhir/view/PatientModel.java
+++ b/src/main/java/org/octri/hpoonfhir/view/PatientModel.java
@@ -1,6 +1,6 @@
 package org.octri.hpoonfhir.view;
 
-import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.r5.model.Patient;
 
 /**
  * The model representing the fields we care about when searching for and displaying a patient

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 app.name=@project.artifactId@
 app.version=@project.version@
 app.displayName=HPO on FHIR
-spring.devtools.livereload.enabled=${SPRING_DEVTOOLS_LIVERELOAD_ENABLED:false}
+spring.devtools.livereload.enabled=false
 
-server.servlet.context-path=${SERVER_CONTEXT_PATH:/hpo-on-fhir}
-server.port=${SERVER_PORT:8080}
+server.servlet.context-path=/hpo-on-fhir
+server.port=8080
 server.use-forward-headers=true
 
 spring.mustache.prefix=classpath:/mustache-templates/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ app.version=@project.version@
 app.displayName=HPO on FHIR
 spring.devtools.livereload.enabled=${SPRING_DEVTOOLS_LIVERELOAD_ENABLED:false}
 
-server.servlet.context-path=${SERVER_CONTEXT_PATH:/}
+server.servlet.context-path=${SERVER_CONTEXT_PATH:/hpo-on-fhir}
 server.port=${SERVER_PORT:8080}
 server.use-forward-headers=true
 
@@ -16,9 +16,11 @@ logging.level.org.springframework=WARN
 logging.level.org.monarchinitiative.phenol=ERROR
 logging.level.org.obolibrary=ERROR
 
-fhir-server-configuration.name=SmartHealth IT
-fhir-server-configuration.url=https://r3.smarthealthit.org
-fhir-server-configuration.version=STU3
+fhir-server-configuration.name=Hapi FHIR
+#fhir-server-configuration.url=https://r4.smarthealthit.org
+fhir-server-configuration.url=http://hapi.fhir.org/baseR5/
+#fhir-server-configuration.url=https://hapi.clinicalprofiles.org/fhir
+fhir-server-configuration.version=R5
 
 #fhir-server-configuration.name=Open Epic
 #fhir-server-configuration.url=https://open-ic.epic.com/FHIR/api/FHIR/DSTU2

--- a/src/main/resources/mustache-templates/browse.html
+++ b/src/main/resources/mustache-templates/browse.html
@@ -3,7 +3,10 @@
 
 <div class="container vertical-space">
 	<div>
-		<p>This SMART on FHIR application demonstrates the use of the <a href="https://github.com/OCTRI/fhir2hpo">fhir2hpo</a> Java library for converting laboratory results with LOINC information to terms in the <a href="https://hpo.jax.org/app/">Human Phenotype Ontology</a>. You can browse a few patients in the unauthenticated {{fhirServiceName}} FHIR sandbox. For each patient, the application gathers all FHIR observations and displays any phenotypes it is able to derive from the results.</p>
+		<p>This SMART on FHIR application demonstrates the ability to find and report suspected phenotypes 
+		for a patient based on clinical data retrieved from a FHIR server. Patient lab results are 
+		retrieved and converted to terms in the <a href="https://hpo.jax.org/app/">Human Phenotype Ontology</a>. 
+		The phenotypes can be appended to the patient record in FHIR for analysis and diagnostics.</p>
 	</div>
 </div>
 

--- a/src/main/resources/mustache-templates/phenotypes.html
+++ b/src/main/resources/mustache-templates/phenotypes.html
@@ -9,7 +9,7 @@
 		{{/patient}}
 	</ul>
 	<h3>Phenotypes</h3>
-	<p>These phenotypes are derived from examining LOINC-encoded lab results. Click on the + symbol to see the related labs.</p>
+	<p>These phenotypes are automatically derived from examining lab results in the clinical record. Click on the + symbol to see the relevant lab results. To report the phenotype back to the clinical system, click "Report".</p>
 	<table id="hposummary" class="table table-bordered" style="width: 100%">
 		<thead class="thead-light">
 			<tr>
@@ -17,11 +17,35 @@
 				<th>HPO Term Name</th>
 				<th>HPO Term Id</th>
 				<th># Observations</th>
-				<th>First Date</th>
-				<th>Last Date</th>
+				<th>First Observed</th>
+				<th>Last Observed</th>
+				<th>HPO Report Status</th>
 			</tr>
 		</thead>
 	</table>
+</div>
+
+<div class="modal fade" id="CommentsModal" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 id="modal-title"></h3>
+            </div>
+            <form id="commentsForm" method="post" action="{{req.contextPath}}/reportHpo">
+	            <div class="modal-body">
+             		<input type="hidden" name="patientId" value="{{#patient}}{{id}}{{/patient}}"></input>
+            		<input type="hidden" id="modal-termid" name="hpoTermId"></input>
+            		<input type="hidden" id="modal-termname" name="hpoTermName"></input>
+            		<input type="hidden" id="modal-observations" name="observations"></input>
+            		<textarea id="modal-comments form-control" name="comments" rows="3" cols="50"></textarea>
+	            </div>
+	            <div class="modal-footer">
+	                <button class="btn btn-primary" type="submit">Submit</button>
+	                <button type="button" class="btn btn-link" data-dismiss="modal">Close</button>
+	            </div>
+            </form>
+        </div>
+    </div>
 </div>
 
 {{>layout/footer}}

--- a/src/main/resources/mustache-templates/phenotypes.html
+++ b/src/main/resources/mustache-templates/phenotypes.html
@@ -29,15 +29,15 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h3 id="modal-title"></h3>
+                <h3 id="CommentsModal-title"></h3>
             </div>
             <form id="commentsForm" method="post" action="{{req.contextPath}}/reportHpo">
 	            <div class="modal-body">
              		<input type="hidden" name="patientId" value="{{#patient}}{{id}}{{/patient}}"></input>
-            		<input type="hidden" id="modal-termid" name="hpoTermId"></input>
-            		<input type="hidden" id="modal-termname" name="hpoTermName"></input>
-            		<input type="hidden" id="modal-observations" name="observations"></input>
-            		<textarea id="modal-comments form-control" name="comments" rows="3" cols="50"></textarea>
+            		<input type="hidden" id="CommentsModal-termid" name="hpoTermId"></input>
+            		<input type="hidden" id="CommentsModal-termname" name="hpoTermName"></input>
+            		<input type="hidden" id="CommentsModal-observations" name="observations"></input>
+            		<textarea id="CommentsModal-comments form-control" name="comments" rows="3" cols="50"></textarea>
 	            </div>
 	            <div class="modal-footer">
 	                <button class="btn btn-primary" type="submit">Submit</button>

--- a/src/main/resources/static/js/hposummary.js
+++ b/src/main/resources/static/js/hposummary.js
@@ -25,7 +25,7 @@ $(document).ready(function() {
 		table += "</tbody></table></div>";
 		return table;
 	}
-
+	
 	let patientId = $("#patient_id").html();
 
 	// Set up table
@@ -39,17 +39,28 @@ $(document).ready(function() {
 		fnDrawCallback: function( settings ) {
 			$('td.details-control').html('<i class="fas fa-plus-square"></i>');
 	    },
-		columns : [ {
-			"className" : "details-control",
-			"orderable" : false,
-			"data" : null,
-			"defaultContent" : ''
+		columns : [ 
+			{
+				"className" : "details-control",
+				"orderable" : false,
+				"data" : null
 			}, 
 			{ "data" : "hpoTermName" }, 
 			{ "data" : "hpoTermId" },
 			{ "data" : "count"},
 			{ "data" : "first" },
-			{ "data" : "last"}
+			{ "data" : "last"},
+			{ 	
+				"targets": -1,
+				"data" : null,
+				"render": function ( data, type, row, meta ) {
+					if (data.needsUpdate) {
+					  return "<button class='btn btn-secondary'>Report</button>"
+					}
+      				return "<i class='far fa-check-square fa-lg text-success'></i>";
+    			}
+				//"defaultContent" : "<button class='btn btn-secondary'>Report</button>"
+			}
 		],
 		aaSorting : [] // Do not sort any columns initially
 	});
@@ -69,5 +80,18 @@ $(document).ready(function() {
 			$(this).html('<i class="fas fa-minus-square"></i>');
 		}
 	});
-
+	
+	$('#hposummary tbody').on( 'click', 'button', function () {
+ 		var tr = $(this).closest('tr');
+		var row = table.row(tr);
+        var data = row.data();
+        console.log(data);
+        $('#CommentsModal').modal("show");
+        $('#modal-title').text("Comments for " + data.hpoTermName);
+        $('#modal-termid').val(data.hpoTermId);
+        $('#modal-termname').val(data.hpoTermName);
+        $('#modal-observations').val(data.observations.map(o => o.fhirId).toString());
+        $('#modal-comments').val("");        
+    } );
+    
 });

--- a/src/main/resources/static/js/hposummary.js
+++ b/src/main/resources/static/js/hposummary.js
@@ -43,7 +43,8 @@ $(document).ready(function() {
 			{
 				"className" : "details-control",
 				"orderable" : false,
-				"data" : null
+				"data" : null,
+				"defaultContent" : ''
 			}, 
 			{ "data" : "hpoTermName" }, 
 			{ "data" : "hpoTermId" },
@@ -59,7 +60,6 @@ $(document).ready(function() {
 					}
       				return "<i class='far fa-check-square fa-lg text-success'></i>";
     			}
-				//"defaultContent" : "<button class='btn btn-secondary'>Report</button>"
 			}
 		],
 		aaSorting : [] // Do not sort any columns initially

--- a/src/main/resources/static/js/hposummary.js
+++ b/src/main/resources/static/js/hposummary.js
@@ -87,11 +87,11 @@ $(document).ready(function() {
         var data = row.data();
         console.log(data);
         $('#CommentsModal').modal("show");
-        $('#modal-title').text("Comments for " + data.hpoTermName);
-        $('#modal-termid').val(data.hpoTermId);
-        $('#modal-termname').val(data.hpoTermName);
-        $('#modal-observations').val(data.observations.map(o => o.fhirId).toString());
-        $('#modal-comments').val("");        
+        $('#CommentsModal-title').text("Comments for " + data.hpoTermName);
+        $('#CommentsModal-termid').val(data.hpoTermId);
+        $('#CommentsModal-termname').val(data.hpoTermName);
+        $('#CommentsModal-observations').val(data.observations.map(o => o.fhirId).toString());
+        $('#CommentsModal-comments').val("");        
     } );
     
 });

--- a/src/test/java/org/octri/hpoonfhir/SeedFHIRServer.java
+++ b/src/test/java/org/octri/hpoonfhir/SeedFHIRServer.java
@@ -1,0 +1,49 @@
+package org.octri.hpoonfhir;
+
+import static org.junit.Assert.assertEquals;
+
+import org.hl7.fhir.r5.model.Observation;
+import org.hl7.fhir.r5.model.Patient;
+import org.hl7.fhir.r5.model.Reference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.octri.hpoonfhir.service.FhirService;
+import org.octri.hpoonfhir.util.FhirParseUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@TestPropertySource("classpath:application.properties")
+public class SeedFHIRServer {
+	
+	@Autowired
+	FhirService fhirService;
+	
+	@Test
+	public void testAutowiring() {
+		Patient patient = fhirService.findPatientById("1505");
+		assertEquals("Patient exists", "1505", patient.getIdElement().getIdPart());
+	}
+	
+	@Test 
+	public void seedServer() {
+    	Patient patient = FhirParseUtils.getPatient("fhir/patient/patient1.json");
+		Patient patientWithId = fhirService.createUpdatePatient(patient);
+		System.out.println("Patient ID: " + patientWithId.getIdElement().getIdPart());
+		
+		Observation observation = FhirParseUtils.getObservation("fhir/observation/glucoseHigh.json");
+		Reference reference = new Reference(patientWithId);
+		observation.setSubject(reference);
+		Observation observationWithId = fhirService.createUpdateObservation(observation);
+		System.out.println("Observation ID: " + observationWithId.getIdElement().getIdPart());
+
+//		observation = FhirParseUtils.getObservation("fhir/observation/bilirubinPositive.json");
+//		observation.setSubject(reference);
+//		observationWithId = fhirService.createUpdateObservation(observation);
+//		System.out.println("Observation ID: " + observationWithId.getIdElement().getIdPart());
+	}
+
+}

--- a/src/test/java/org/octri/hpoonfhir/util/FhirParseUtils.java
+++ b/src/test/java/org/octri/hpoonfhir/util/FhirParseUtils.java
@@ -1,0 +1,41 @@
+package org.octri.hpoonfhir.util;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import org.hl7.fhir.r5.model.Observation;
+import org.hl7.fhir.r5.model.Patient;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+
+/**
+ * Utility for processing FHIR R5 resources.
+ * 
+ * @author yateam
+ *
+ */
+public class FhirParseUtils {
+	
+	// This is expensive and should only be declared once
+	private static final FhirContext fhirContext = FhirContext.forR5();
+	
+	public FhirContext getR5FhirContext() {
+		return fhirContext;
+	}
+
+	// Parse an observation given the path to the file
+	public static Observation getObservation(String path) {
+		IParser parser = fhirContext.newJsonParser();
+		InputStream stream = FhirParseUtils.class.getClassLoader().getResourceAsStream(path);
+		return (Observation) parser.parseResource(new InputStreamReader(stream));
+	}
+
+	// Parse an observation given the path to the file
+	public static Patient getPatient(String path) {
+		IParser parser = fhirContext.newJsonParser();
+		InputStream stream = FhirParseUtils.class.getClassLoader().getResourceAsStream(path);
+		return (Patient) parser.parseResource(new InputStreamReader(stream));
+	}
+
+}

--- a/src/test/resources/fhir/observation/bilirubinPositive.json
+++ b/src/test/resources/fhir/observation/bilirubinPositive.json
@@ -1,0 +1,30 @@
+{
+	"resourceType": "Observation",
+	"id": "1654",
+	"text": {
+		"status": "generated",
+		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">2020-09-16: Bilirub Ur Ql Strip = Negative </div>"
+	},
+	"status": "unknown",
+	"category": [{
+		"coding": [{
+			"system": "http://hl7.org/fhir/observation-category",
+			"code": "laboratory",
+			"display": "Laboratory"
+		}],
+		"text": "Laboratory"
+	}],
+	"code": {
+		"coding": [{
+			"system": "http://loinc.org",
+			"code": "5770-3",
+			"display": "Bilirub Ur Ql Strip"
+		}],
+		"text": "Bilirub Ur Ql Strip"
+	},
+	"subject": {
+		"reference": "Patient/1652"
+	},
+	"effectiveDateTime": "2020-09-16",
+	"valueString": "Positive"
+}

--- a/src/test/resources/fhir/observation/glucoseHigh.json
+++ b/src/test/resources/fhir/observation/glucoseHigh.json
@@ -1,0 +1,57 @@
+{
+  "resourceType": "Observation",
+  "id": "1656",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: f001</p><p><b>identifier</b>: 6323 (OFFICIAL)</p><p><b>status</b>: final</p><p><b>code</b>: Glucose [Moles/volume] in Blood <span>(Details : {LOINC code '15074-8' = 'Glucose [Moles/volume] in Blood', given as 'Glucose [Moles/volume] in Blood'})</span></p><p><b>subject</b>: <a>P. van de Heuvel</a></p><p><b>effective</b>: 02/04/2013 9:30:10 AM --&gt; (ongoing)</p><p><b>issued</b>: 03/04/2013 3:30:10 PM</p><p><b>performer</b>: <a>A. Langeveld</a></p><p><b>value</b>: 6.3 mmol/l<span> (Details: UCUM code mmol/L = 'mmol/L')</span></p><p><b>interpretation</b>: High <span>(Details : {http://hl7.org/fhir/v2/0078 code 'H' = 'High', given as 'High'})</span></p><h3>ReferenceRanges</h3><table><tr><td>-</td><td><b>Low</b></td><td><b>High</b></td></tr><tr><td>*</td><td>3.1 mmol/l<span> (Details: UCUM code mmol/L = 'mmol/L')</span></td><td>6.2 mmol/l<span> (Details: UCUM code mmol/L = 'mmol/L')</span></td></tr></table></div>"
+  },
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "15074-8",
+        "display": "Glucose [Moles/volume] in Blood"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/1652",
+    "display": "John McLean"
+  },
+  "effectivePeriod": {
+    "start": "2018-06-19T09:30:10+01:00"
+  },
+  "issued": "2019-04-03T15:30:10+01:00",
+  "valueQuantity": {
+    "value": 7.4,
+    "unit": "mmol/l",
+    "system": "http://unitsofmeasure.org",
+    "code": "mmol/L"
+  },
+  "interpretation": [{
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v2/0078",
+        "code": "H",
+        "display": "High"
+      }
+    ]
+  }],
+  "referenceRange": [
+    {
+      "low": {
+        "value": 3.1,
+        "unit": "mmol/l",
+        "system": "http://unitsofmeasure.org",
+        "code": "mmol/L"
+      },
+      "high": {
+        "value": 6.2,
+        "unit": "mmol/l",
+        "system": "http://unitsofmeasure.org",
+        "code": "mmol/L"
+      }
+    }
+  ]
+}

--- a/src/test/resources/fhir/patient/patient1.json
+++ b/src/test/resources/fhir/patient/patient1.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "Patient",
+  "id": "1652",
+  "active": true,
+  "name": [ {
+    "use": "official",
+    "family": "McLean",
+    "given": [ "John" ]
+  }],
+  "gender": "male",
+  "birthDate": "1980-12-25",
+  "deceasedBoolean": false
+}


### PR DESCRIPTION
- Upgrade to latest fhir2hpo and hapi-fhir libraries
- Create an R5 FHIR Service and focus on connecting only to R5 for Connectathon
- Add actions for reporting the phenotypes back to the FHIR service with comments
- Check for phenotypes already reported and display a checkbox when no update is needed

Feel free to ignore most of this pull request, but some feedback on phenotypes.html and hposummary.js would be helpful.